### PR TITLE
Adding gltf export

### DIFF
--- a/src/simenv/__init__.py
+++ b/src/simenv/__init__.py
@@ -20,6 +20,7 @@
 __version__ = "0.0.1.dev0"
 
 from .assets import *
+from .gltf_export import *  # TODO cleanup all these * import
 from .gltf_import import *
 from .renderer.unity import Unity
 from .scene import Scene

--- a/src/simenv/assets/__init__.py
+++ b/src/simenv/assets/__init__.py
@@ -2,4 +2,4 @@ from .agent import Agent
 from .asset import *
 from .camera import Camera
 from .light import DirectionalLight, Light, PointLight, SpotLight
-from .object import Capsule, Cube, Cylinder, Object, Plane, Primitive, Quad, Sphere
+from .object import Capsule, Cube, Cylinder, Object, Sphere

--- a/src/simenv/assets/object.py
+++ b/src/simenv/assets/object.py
@@ -1,13 +1,13 @@
-from typing import List, Optional
+from optparse import Option
+from typing import List, Optional, Union
 
-from trimesh import Trimesh
+import trimesh
 
 from .asset import Asset
 
 
 class Object(Asset):
     dimensionality = 3
-    dynamic = False
 
     def __init__(
         self,
@@ -15,7 +15,8 @@ class Object(Asset):
         translation: Optional[List[float]] = [0.0, 0.0, 0.0],
         rotation: Optional[List[float]] = [0.0, 0.0, 0.0, 1.0],
         scale: Optional[List[float]] = [1.0, 1.0, 1.0],
-        mesh: Optional[Trimesh] = None,
+        mesh: Optional[trimesh.Trimesh] = None,
+        dynamic: bool = False,
         parent: Optional[Asset] = None,
         children: Optional[List[Asset]] = None,
     ):
@@ -23,35 +24,162 @@ class Object(Asset):
             name=name, translation=translation, rotation=rotation, scale=scale, parent=parent, children=children
         )
         self.mesh = mesh
+        self.dynamic = dynamic
 
     def __repr__(self):
         return f"{self.name} ({self.__class__.__name__} - Mesh={self.mesh})"
 
 
-class Primitive(Object):
-    dynamic = True
-    pass
+class Sphere(Object):
+    """
+    An isosphere or a UV sphere (latitude + longitude).
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        radius: Optional[float] = 1.0,
+        subdivisions: Optional[int] = None,
+        count: Optional[List[int]] = None,
+        theta: Optional[List[float]] = None,
+        phi: Optional[List[float]] = None,
+        type: Optional[str] = "uv",
+        translation: Optional[List[float]] = [0.0, 0.0, 0.0],
+        rotation: Optional[List[float]] = [0.0, 0.0, 0.0, 1.0],
+        scale: Optional[List[float]] = [1.0, 1.0, 1.0],
+        dynamic: Optional[bool] = False,
+        parent: Optional[Asset] = None,
+        children: Optional[List[Asset]] = None,
+    ):
+        if type == "uv":
+            if subdivisions is not None:
+                raise ValueError(
+                    "You cannot use 'subdivisions' with a sphere of type 'uv'. "
+                    "Specify the mesh with 'count', 'theta' or 'phi' or change the 'type' of the Sphere."
+                )
+            if count is None:
+                count = [32, 32]
+            mesh = trimesh.creation.uv_sphere(radius=radius, count=count, theta=theta, phi=phi)
+        elif type == "iso":
+            if count is not None or theta is not None or phi is not None:
+                raise ValueError(
+                    "You cannot use 'count', 'theta' or 'phi' with a sphere of type 'iso'. "
+                    "Specify the mesh with 'subdivisions' instead or change the 'type' of the Sphere."
+                )
+            if subdivisions is None:
+                subdivisions = 3
+            mesh = trimesh.creation.icosphere(radius=radius, subdivisions=subdivisions)
+        else:
+            raise ValueError("Sphere type should be one of 'uv' or 'iso'.")
+
+        super().__init__(
+            mesh=mesh,
+            name=name,
+            translation=translation,
+            rotation=rotation,
+            scale=scale,
+            dynamic=dynamic,
+            parent=parent,
+            children=children,
+        )
 
 
-class Sphere(Primitive):
-    pass
+class Capsule(Object):
+    """
+    A capsule (a cylinder with hemispheric ends).
+
+    Parameters
+    ----------
+    height : float
+      Center to center distance of two spheres
+    radius : float
+      Radius of the cylinder and hemispheres
+    count : (2,) int
+      Number of sections on latitude and longitude
+
+    Returns
+    ----------
+    capsule : trimesh.Trimesh
+      Capsule geometry with:
+        - cylinder axis is along Z
+        - one hemisphere is centered at the origin
+        - other hemisphere is centered along the Z axis at height
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        height: Optional[float] = 1.0,
+        radius: Optional[float] = 1.0,
+        count: Optional[List[int]] = [32, 32],
+        translation: Optional[List[float]] = [0.0, 0.0, 0.0],
+        rotation: Optional[List[float]] = [0.0, 0.0, 0.0, 1.0],
+        scale: Optional[List[float]] = [1.0, 1.0, 1.0],
+        dynamic: Optional[bool] = False,
+        parent: Optional[Asset] = None,
+        children: Optional[List[Asset]] = None,
+    ):
+        mesh = trimesh.creation.capsule(height=height, radius=radius, count=count)
+        super().__init__(
+            mesh=mesh,
+            name=name,
+            translation=translation,
+            rotation=rotation,
+            scale=scale,
+            dynamic=dynamic,
+            parent=parent,
+            children=children,
+        )
 
 
-class Capsule(Primitive):
-    pass
+class Cylinder(Object):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        height: Optional[float] = 1.0,
+        radius: Optional[float] = 1.0,
+        sections: Optional[int] = 32,
+        segment: Optional[List[float]] = None,
+        translation: Optional[List[float]] = [0.0, 0.0, 0.0],
+        rotation: Optional[List[float]] = [0.0, 0.0, 0.0, 1.0],
+        scale: Optional[List[float]] = [1.0, 1.0, 1.0],
+        dynamic: Optional[bool] = False,
+        parent: Optional[Asset] = None,
+        children: Optional[List[Asset]] = None,
+    ):
+        mesh = trimesh.creation.cylinder(radius=radius, height=height, sections=sections, segment=segment)
+        super().__init__(
+            mesh=mesh,
+            name=name,
+            translation=translation,
+            rotation=rotation,
+            scale=scale,
+            dynamic=dynamic,
+            parent=parent,
+            children=children,
+        )
 
 
-class Cylinder(Primitive):
-    pass
-
-
-class Cube(Primitive):
-    pass
-
-
-class Plane(Primitive):
-    pass
-
-
-class Quad(Primitive):
-    pass
+class Cube(Object):
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        extents: Optional[Union[float, List[float]]] = None,
+        translation: Optional[List[float]] = [0.0, 0.0, 0.0],
+        rotation: Optional[List[float]] = [0.0, 0.0, 0.0, 1.0],
+        scale: Optional[List[float]] = [1.0, 1.0, 1.0],
+        dynamic: Optional[bool] = False,
+        parent: Optional[Asset] = None,
+        children: Optional[List[Asset]] = None,
+    ):
+        mesh = trimesh.creation.box(extents=extents)
+        super().__init__(
+            mesh=mesh,
+            name=name,
+            translation=translation,
+            rotation=rotation,
+            scale=scale,
+            dynamic=dynamic,
+            parent=parent,
+            children=children,
+        )

--- a/src/simenv/gltf_export.py
+++ b/src/simenv/gltf_export.py
@@ -13,68 +13,412 @@
 # limitations under the License.
 
 # Lint as: python3
-""" Load a GLTF file in a Scene."""
+""" Export a Scene as a GLTF file."""
 from copy import deepcopy
-from typing import ByteString, List, Set
+from io import BytesIO
+from typing import ByteString, List, Optional, Set, Tuple
 
 import numpy as np
 import PIL.Image
 import trimesh
-from trimesh.exchange.gltf import export_glb
+from trimesh.exchange.gltf import export_gltf
 
 # from trimesh.path.entities import Line  # Line need scipy
 from trimesh.visual.material import PBRMaterial
 from trimesh.visual.texture import TextureVisuals
 
-from simenv.gltflib.models import material
+from simenv.gltflib.models.extensions.khr_lights_ponctual import KHRLightsPunctualLight
 
-from .assets import (
-    Asset,
-    Camera,
-    Capsule,
-    Cube,
-    Cylinder,
-    DirectionalLight,
-    Object,
-    PointLight,
-    Primitive,
-    Sphere,
-    SpotLight,
-)
-from .gltflib import GLTF, GLTFModel, Material
-from .gltflib.enums import AccessorType, ComponentType, PrimitiveMode
+from . import gltflib as gl
+from .assets import Asset, Camera, DirectionalLight, Light, Object, PointLight, SpotLight
+from .gltflib.utils import padbytes
 
 
-def add_node_tree_to_scene(node: Asset, trimesh_scene: trimesh.Scene, parent_node_name=None) -> trimesh.Scene:
-    if isinstance(node, Object):
-        geometry = None
-        if isinstance(node, Sphere):
-            geometry = (
-                trimesh.creation.uv_sphere()
-            )  # TODO we will want this mesh creation at the initialization of the object and inside the object __init__, not when sending the object
-        elif isinstance(node, Capsule):
-            geometry = trimesh.creation.capsule()
-        elif isinstance(node, Cylinder):
-            geometry = trimesh.creation.cylinder(1)
-        elif isinstance(node, Cube):
-            geometry = trimesh.creation.box()
+# Conversion of Numnpy dtype and shapes in GLTF equivalents
+NP_FLOAT32 = np.dtype("<f4")
+NP_UINT32 = np.dtype("<u4")
+NP_UINT8 = np.dtype("<u1")
+
+numpy_to_gltf_dtypes_mapping = {
+    np.dtype("<i1"): gl.ComponentType.BYTE,
+    np.dtype("<u1"): gl.ComponentType.UNSIGNED_BYTE,
+    np.dtype("<i2"): gl.ComponentType.SHORT,
+    np.dtype("<u2"): gl.ComponentType.UNSIGNED_SHORT,
+    np.dtype("<u4"): gl.ComponentType.UNSIGNED_INT,
+    np.dtype("<f4"): gl.ComponentType.FLOAT,
+}
+
+numpy_to_gltf_shapes_mapping = {
+    (1,): gl.AccessorType.SCALAR,
+    (2,): gl.AccessorType.VEC2,
+    (3,): gl.AccessorType.VEC3,
+    (4,): gl.AccessorType.VEC4,
+    (2, 2): gl.AccessorType.MAT2,
+    (3, 3): gl.AccessorType.MAT3,
+    (4, 4): gl.AccessorType.MAT4,
+}
+
+
+lights_to_gltf_mapping = {SpotLight: "spot", DirectionalLight: "directional", PointLight: "point"}
+
+
+def add_data_to_gltf(new_data: bytearray, gltf_model: gl.GLTFModel, buffer_data: bytearray, buffer_id: int = 0) -> int:
+    """Add byte data to the buffer_data, create/add a new buffer view for it in the scene and return the index of the added buffer view"""
+    # Pad the current buffer to a multiple of 4 bytes for GLTF alignement
+    byte_offset = padbytes(buffer_data, 4)
+
+    # Pad new data to a multiple of 4 bytes as well
+    byte_length = padbytes(new_data, 4)
+
+    # Add our binary data to the end of the buffer
+    buffer_data.extend(new_data)
+
+    # Create/add a new bufferView
+    buffer_view = gl.BufferView(buffer=buffer_id, byteLength=byte_length, byteOffset=byte_offset, byteStride=0)
+    gltf_model.bufferViews.append(buffer_view)
+    buffer_view_id = len(gltf_model.bufferViews) - 1
+
+    return buffer_view_id
+
+
+def add_numpy_to_gltf(
+    np_array: np.ndarray,
+    gltf_model: gl.GLTFModel,
+    buffer_data: bytearray,
+    normalized: Optional[bool] = False,
+    buffer_id: int = 0,
+) -> int:
+    """Create/add GLTF accessor and bufferview to the GLTF scene to store a numpy array and add the numpy array in the buffer_data."""
+    component_type: gl.ComponentType = numpy_to_gltf_dtypes_mapping[np_array.dtype]
+    accessor_type: gl.AccessorType = numpy_to_gltf_shapes_mapping[np_array.shape[1:]]
+
+    if (
+        accessor_type == gl.AccessorType.MAT2
+        and component_type in [gl.ComponentType.BYTE, gl.ComponentType.UNSIGNED_BYTE]
+    ) or (
+        accessor_type == gl.AccessorType.MAT3
+        and component_type
+        in [
+            gl.ComponentType.BYTE,
+            gl.ComponentType.UNSIGNED_BYTE,
+            gl.ComponentType.SHORT,
+            gl.ComponentType.UNSIGNED_SHORT,
+        ]
+    ):
+        raise NotImplementedError(
+            "Column padding should be implemented in these cases."
+            "Cf https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#data-alignment"
+        )
+
+    count: int = np_array.shape[0]
+    max = np_array.max(axis=0).reshape(-1).tolist()
+    min = np_array.min(axis=0).reshape(-1).tolist()
+
+    new_data = np_array.tobytes()
+    buffer_view_id = add_data_to_gltf(
+        new_data=new_data, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+    )
+
+    # Create and add a new Accessor
+    accessor = gl.Accessor(
+        bufferView=buffer_view_id,
+        byteOffset=0,
+        componentType=component_type.value,
+        normalized=normalized,
+        type=accessor_type.value,
+        count=count,
+        min=min,
+        max=max,
+        sparse=False,
+    )
+    gltf_model.accessors.append(accessor)
+    accessor_id = len(gltf_model.accessors) - 1
+
+    return accessor_id
+
+
+def add_image_to_gltf(image: PIL.Image, gltf_model: gl.GLTFModel, buffer_data: bytearray, buffer_id: int = 0) -> int:
+    """Create/add GLTF accessor and bufferview to the GLTF scene to store a numpy array and add the numpy array in the buffer_data."""
+    # From trimesh
+    # probably not a PIL image so exit
+    if not hasattr(image, "format"):
+        return None
+
+    # don't re-encode JPEGs
+    if image.format == "JPEG":
+        # no need to mangle JPEGs
+        save_as = "JPEG"
+    else:
+        # for everything else just use PNG
+        save_as = "png"
+
+    # get the image data into a bytes object
+    with BytesIO() as f:
+        image.save(f, format=save_as)
+        f.seek(0)
+        data = f.read()
+
+    buffer_view_id = add_data_to_gltf(
+        new_data=data, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+    )
+
+    gltf_image = gl.Image(bufferView=buffer_view_id, mimeType="image/{}".format(save_as.lower()))
+    gltf_model.images.append(gltf_image)
+    image_id = len(gltf_model.images) - 1
+
+    gltf_model.textures.append(gl.Texture(source=image_id))
+    texture_id = len(gltf_model.textures) - 1
+
+    return texture_id
+
+
+def add_material_to_gltf(
+    tm_material: trimesh.visual.material.PBRMaterial,
+    gltf_model: gl.GLTFModel,
+    buffer_data: bytearray,
+    buffer_id: int = 0,
+) -> int:
+    """Add GLTF accessor and bufferview to the GLTF scene to store a numpy array and add the numpy array in the buffer_data."""
+    # convert passed input to PBR if necessary
+    if hasattr(tm_material, "to_pbr"):
+        tm_material = tm_material.to_pbr()
+
+    # From trimesh
+    # Store keys of the PBRMaterial which are images
+    images_to_add = {
+        "baseColorTexture": tm_material.baseColorTexture,
+        "emissiveTexture": tm_material.emissiveTexture,
+        "normalTexture": tm_material.normalTexture,
+        "occlusionTexture": tm_material.occlusionTexture,
+        "metallicRoughnessTexture": tm_material.metallicRoughnessTexture,
+    }
+
+    textures_ids = {}
+    for key, image in images_to_add.items():
+        textures_ids[key] = None
+        if image is not None:
+            texture_id = add_image_to_gltf(
+                image=image, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+            )
+            textures_ids[key] = gl.TextureInfo(index=texture_id)
+
+    pbr_metallic_roughness = gl.PBRMetallicRoughness(
+        metallicFactor=tm_material.metallicFactor if isinstance(tm_material.metallicFactor, float) else None,
+        roughnessFactor=tm_material.roughnessFactor if isinstance(tm_material.roughnessFactor, float) else None,
+        baseColorTexture=textures_ids["baseColorTexture"],
+        metallicRoughnessTexture=textures_ids["metallicRoughnessTexture"],
+    )
+    try:  # try to convert base color to (4,) float color
+        pbr_metallic_roughness.baseColorFactor = (
+            trimesh.visual.color.to_float(tm_material.baseColorFactor).reshape(4).tolist()
+        )
+    except BaseException:
+        pass
+
+    material = gl.Material(
+        name=tm_material.name if isinstance(tm_material.name, str) else None,
+        pbrMetallicRoughness=pbr_metallic_roughness,
+        normalTexture=textures_ids["normalTexture"],
+        occlusionTexture=textures_ids["occlusionTexture"],
+        emissiveTexture=textures_ids["emissiveTexture"],
+        alphaMode=tm_material.alphaMode if isinstance(tm_material.alphaMode, str) else None,
+        alphaCutoff=tm_material.alphaCutoff if isinstance(tm_material.alphaCutoff, float) else None,
+        doubleSided=tm_material.doubleSided if isinstance(tm_material.doubleSided, bool) else None,
+    )
+    try:
+        material.emissiveFactor = tm_material.emissiveFactor.reshape(3).tolist()
+    except BaseException:
+        pass
+
+    # Add the new material
+    gltf_model.materials.append(material)
+    material_id = len(gltf_model.materials) - 1
+
+    return material_id
+
+
+def add_mesh_to_model(
+    tm_mesh: trimesh.Trimesh, gltf_model: gl.GLTFModel, buffer_data: ByteString, buffer_id: int = 0
+) -> int:
+    if len(tm_mesh.faces) == 0 or len(tm_mesh.vertices) == 0:
+        raise NotImplementedError()
+
+    # Build attributes, primitive and mesh
+    attributes = gl.Attributes()
+    primitive = gl.Primitive(mode=gl.PrimitiveMode.TRIANGLES.value, attributes=attributes)
+    mesh = gl.Mesh(primitives=[primitive])
+
+    # Store vertex positions
+    np_array = tm_mesh.vertices.astype(NP_FLOAT32)
+    attributes.POSITION = add_numpy_to_gltf(
+        np_array=np_array, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+    )
+
+    # store vertex normals (TODO maybe not always necessary?)
+    np_array = tm_mesh.vertex_normals.astype(NP_FLOAT32)
+    attributes.NORMAL = add_numpy_to_gltf(
+        np_array=np_array, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+    )
+
+    # check to see if we have vertex or face colors or if a TextureVisual has colors included as an attribute
+    vertex_colors = None
+    if tm_mesh.visual.kind in ["vertex", "face"]:
+        vertex_colors = tm_mesh.visual.vertex_colors
+    elif hasattr(tm_mesh.visual, "vertex_attributes") and "color" in tm_mesh.visual.vertex_attributes:
+        vertex_colors = tm_mesh.visual.vertex_attributes["color"]
+    if vertex_colors is not None:
+        np_array = vertex_colors.astype(NP_UINT8)
+        attributes.COLOR_0 = add_numpy_to_gltf(
+            np_array=np_array, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+        )
+
+    # Store face indices
+    np_array = tm_mesh.faces.astype(NP_UINT32)
+    primitive.indices = add_numpy_to_gltf(
+        np_array=np_array, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+    )
+
+    # append the material and then set from returned index
+    if hasattr(tm_mesh.visual, "material"):
+        material_id = add_material_to_gltf(
+            tm_material=tm_mesh.visual.material, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+        )
+        primitive.material = material_id
+
+        # if tm_mesh has UV coordinates defined export them
+        has_uv = (
+            hasattr(tm_mesh.visual, "uv")
+            and tm_mesh.visual.uv is not None
+            and len(tm_mesh.visual.uv) == len(tm_mesh.vertices)
+        )
+        if has_uv:
+            # slice off W if passed
+            uv = tm_mesh.visual.uv.copy()[:, :2]
+            # reverse the Y for GLTF
+            uv[:, 1] = 1.0 - uv[:, 1]
+
+            # Store uv coords
+            np_array = uv.astype(NP_FLOAT32)
+            uv_accessor_id = add_numpy_to_gltf(
+                np_array=np_array, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+            )
+            attributes.TEXCOORD_0 = uv_accessor_id
+
+    # Add the new mesh
+    gltf_model.meshes.append(mesh)
+    mesh_id = len(gltf_model.meshes) - 1
+
+    return mesh_id
+
+
+def add_camera_to_model(camera: Camera, gltf_model: gl.GLTFModel, buffer_data: ByteString, buffer_id: int = 0) -> int:
+    gl_camera = gl.Camera(type=camera.camera_type)
+
+    if camera.camera_type == "perspective":
+        gl_camera.perspective = gl.PerspectiveCameraInfo(
+            aspectRatio=camera.aspect_ratio, yfov=camera.yfov, zfar=camera.zfar, znear=camera.znear
+        )
+    else:
+        gl_camera.orthographic = gl.OrthographicCameraInfo(
+            xmag=camera.xmag, ymag=camera.ymag, zfar=camera.zfar, znear=camera.znear
+        )
+
+    # Add the new camera
+    gltf_model.cameras.append(gl_camera)
+    camera_id = len(gltf_model.cameras) - 1
+
+    return camera_id
+
+
+def add_light_to_model(node: Light, gltf_model: gl.GLTFModel, buffer_data: ByteString, buffer_id: int = 0) -> int:
+    light_type = lights_to_gltf_mapping[node.__class__]
+
+    light = gl.KHRLightsPunctualLight(type=light_type, color=node.color, intensity=node.intensity, range=node.range)
+
+    # Add the new light
+    if gltf_model.extensions.KHR_lights_punctual is None:
+        gltf_model.extensions.KHR_lights_punctual = gl.KHRLightsPunctual(lights=[light])
+    else:
+        gltf_model.extensions.KHR_lights_punctual.lights.append(light)
+    light_id = len(gltf_model.extensions.KHR_lights_punctual.lights) - 1
+
+    return light_id
+
+
+def add_node_to_scene(
+    node: Asset,
+    gltf_model: gl.GLTFModel,
+    buffer_data: ByteString,
+    gl_parent_node_id: Optional[int] = None,
+    buffer_id: Optional[int] = 0,
+):
+    gl_node = gl.Node(name=node.name, translation=node.translation, rotation=node.rotation, scale=node.scale)
+    if isinstance(node, Camera):
+        gl_node.camera = add_camera_to_model(
+            camera=node, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+        )
+    elif isinstance(node, Light):
+        light_id = add_light_to_model(node=node, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id)
+        gl_node.extensions = gl.Extensions(KHR_lights_punctual=gl.KHRLightsPunctual(light=light_id))
+    elif isinstance(node, Object):
+        gl_node.mesh = add_mesh_to_model(
+            tm_mesh=node.mesh, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=buffer_id
+        )
+
+    # Add the new node
+    gltf_model.nodes.append(gl_node)
+    gl_node_id = len(gltf_model.nodes) - 1
+
+    # List as a child in parent node in GLTF scene if not root node
+    if gl_parent_node_id is not None:
+        if gltf_model.nodes[gl_parent_node_id].children is None:
+            gltf_model.nodes[gl_parent_node_id].children = [gl_node_id]
         else:
-            print(f"Primitive type {node.primitive_type} not implemented for Trimesh view")
-        if geometry is not None:
-            trimesh_scene.add_geometry(
-                geometry=geometry, node_name=node.name, parent_node_name=None
-            )  # TODO we won't be using trimesh for gltf export
+            gltf_model.nodes[gl_parent_node_id].children.append(gl_node_id)
 
-    if node.children is not None:
-        for child in node.children:
-            trimesh_scene = add_node_tree_to_scene(
-                child, trimesh_scene, parent_node_name=None
-            )  #  TODO recreate this parent thing
+    # Add the child nodes to the scene
+    for child_node in node.children:
+        add_node_to_scene(
+            node=child_node,
+            gl_parent_node_id=gl_node_id,
+            gltf_model=gltf_model,
+            buffer_data=buffer_data,
+            buffer_id=buffer_id,
+        )
 
-    return trimesh_scene
+    return
 
 
-def export_assets_to_gltf(root_node: Asset) -> dict:
-    trimesh_scene = trimesh.Scene()
-    trimesh_scene = add_node_tree_to_scene(root_node, trimesh_scene=trimesh_scene)
-    return export_glb(trimesh_scene)
+def export_assets_to_gltf(root_node: Asset, filename: Optional[str] = "scene.gltf"):
+    buffer_data = bytearray()
+    gltf_model = gl.GLTFModel(
+        accessors=[],
+        animations=[],
+        asset=gl.Asset(version="2.0"),
+        buffers=[],
+        bufferViews=[],
+        cameras=[],
+        images=[],
+        materials=[],
+        meshes=[],
+        nodes=[],
+        samplers=[],
+        scene=0,
+        scenes=[gl.Scene(nodes=[0])],
+        skins=[],
+        textures=[],
+        extensions=gl.Extensions(),
+    )
+    add_node_to_scene(node=root_node, gltf_model=gltf_model, buffer_data=buffer_data, buffer_id=0)
+
+    # Update scene requirements with the GLTF extensions we need
+    if gltf_model.extensions.KHR_lights_punctual is not None:
+        gltf_model.extensionsRequired = ["KHRLightsPunctual"]
+        gltf_model.extensionsUsed = ["KHRLightsPunctual"]
+
+    resource = gl.FileResource("scene.bin", data=buffer_data)
+    gltf = gl.GLTF(model=gltf_model, resources=[resource])
+
+    gltf.export("scene.gltf")
+
+    return

--- a/src/simenv/gltf_import.py
+++ b/src/simenv/gltf_import.py
@@ -15,6 +15,7 @@
 # Lint as: python3
 """ Load a GLTF file in a Scene."""
 from copy import deepcopy
+from dataclasses import asdict
 from typing import ByteString, List, Set, Union
 
 import numpy as np
@@ -134,12 +135,12 @@ def get_material_as_trimesh(gltf_scene: GLTF, material_id: int) -> PBRMaterial:
     gltf_material = gltf_materials[material_id]
 
     pbrMetallicRoughness = {}
-    if isinstance(gltf_material.pbrMetallicRoughness.__dict__, dict):
-        pbrMetallicRoughness = deepcopy(gltf_material.pbrMetallicRoughness.__dict__)
+    if gltf_material.pbrMetallicRoughness is not None:
+        pbrMetallicRoughness = deepcopy(asdict(gltf_material.pbrMetallicRoughness))
         del pbrMetallicRoughness["extensions"]
         del pbrMetallicRoughness["extras"]
 
-    other_keys = deepcopy(gltf_material.__dict__)
+    other_keys = deepcopy(asdict(gltf_material))
     del other_keys["pbrMetallicRoughness"]
     del other_keys["extensions"]
     del other_keys["extras"]

--- a/src/simenv/gltflib/gltf.py
+++ b/src/simenv/gltflib/gltf.py
@@ -676,7 +676,7 @@ class GLTF:
                 buffer_view.buffer += 1
         return glb_buffer
 
-    def _create_or_extend_glb_resource(self, data: bytearray) -> (GLBResource, int, int):
+    def _create_or_extend_glb_resource(self, data: bytearray) -> Tuple[GLBResource, int, int]:
         bytelen = len(data)
         glb_resource = self.get_glb_resource()
         if glb_resource is None:

--- a/src/simenv/gltflib/models/__init__.py
+++ b/src/simenv/gltflib/models/__init__.py
@@ -3,10 +3,12 @@ from .animation import Animation
 from .animation_sampler import AnimationSampler
 from .asset import Asset
 from .attributes import Attributes
+from .base_model import Extensions
 from .buffer import Buffer
 from .buffer_view import BufferView
 from .camera import Camera
 from .channel import Channel
+from .extensions import *
 from .gltf_model import GLTFModel
 from .image import Image
 from .material import Material

--- a/src/simenv/gltflib/models/extensions/__init__.py
+++ b/src/simenv/gltflib/models/extensions/__init__.py
@@ -1,0 +1,1 @@
+from .khr_lights_ponctual import *

--- a/src/simenv/scene.py
+++ b/src/simenv/scene.py
@@ -31,7 +31,7 @@ class UnsetRendererError(Exception):
 class Scene:
     def __init__(
         self,
-        renderer: Optional[str] = None,
+        engine: Optional[str] = None,
         dimensionality=3,
         start_frame=0,
         end_frame=500,
@@ -39,15 +39,15 @@ class Scene:
         assets=None,
     ):
 
-        self.renderer = None
-        if renderer == "Unity":
-            self.renderer = Unity(self, start_frame=start_frame, end_frame=end_frame, frame_rate=frame_rate)
-        elif renderer == "Blender":
+        self.engine = None
+        if engine == "Unity":
+            self.engine = Unity(self, start_frame=start_frame, end_frame=end_frame, frame_rate=frame_rate)
+        elif engine == "Blender":
             raise NotImplementedError()
-        elif renderer is None:
+        elif engine is None:
             pass
         else:
-            raise ValueError("renderer should be selected ()")
+            raise ValueError("engine should be selected ()")
 
         self.dimensionality = dimensionality
 
@@ -110,8 +110,8 @@ class Scene:
 
     def render(self):
         gltf_file_path = export_assets_to_gltf(self.root)
-        if self.renderer is not None:
-            self.renderer.send_gltf(gltf_file_path)
+        if self.engine is not None:
+            self.engine.send_gltf(gltf_file_path)
         else:
             raise UnsetRendererError()
 
@@ -124,4 +124,4 @@ class Scene:
         return self
 
     def __repr__(self):
-        return f"Scene(dimensionality={self.dimensionality}, renderer='{self.renderer}, root={self.root}')\n{RenderTree(self.root).print_tree()}"
+        return f"Scene(dimensionality={self.dimensionality}, engine='{self.engine}, root={self.root}')\n{RenderTree(self.root).print_tree()}"


### PR DESCRIPTION
First draft of our own GLTF exporter based on top gltflib instead of using trimesh's one.

Changes:
- We now create object meshes when instantiating the object's. The GLTF exporter assume all object have meshes
- Fix a couple of things on the side in the gltf lib and importer
- Core of the work was writing the `gltf_export.py` file

Currently we export '.gltf' but switching to '.glb'. or to using Base64 ressources is very easy with gltflib.

Example test debug usage:
```
import simenv as sm

scene = sm.Scene.from_gltf('scene-mesh.gltf')

print(scene)

# will save a scene.gltf and a scene.bin files at the root of the repo 
sm.gltf_export.export_assets_to_gltf(scene.root)

```