### PR TITLE
Hotfix for M1.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ import numpy as np
 from Cython.Build import cythonize
 
 from setuptools import find_packages, setup
+import sys
 
 
 REQUIRED_PKGS = [
@@ -85,6 +86,14 @@ EXTRAS_REQUIRE = {
     "quality": QUALITY_REQUIRE,
 }
 
+if sys.platform == 'darwin':
+    extra_compile_args=["-std=c++11"]
+    extra_link_args=["-std=c++11"]
+    
+else:
+    extra_compile_args=[]
+    extra_link_args=[]
+
 ext_modules = [
    Extension(
       name="wfc_binding",
@@ -93,6 +102,8 @@ ext_modules = [
                "src/simenv/assets/procgen/wfc/core/cpp/src/wave.cpp",
                "src/simenv/assets/procgen/wfc/core/cpp/src/wfc.cpp"],
       language="c++",
+      extra_compile_args=extra_compile_args,
+      extra_link_args=extra_link_args,
       include_dirs=[
             "src/simenv/assets/procgen/wfc/core/cpp/include",
       ],

--- a/src/simenv/assets/procgen/wfc/core/cpp/include/overlapping_wfc.hpp
+++ b/src/simenv/assets/procgen/wfc/core/cpp/include/overlapping_wfc.hpp
@@ -36,7 +36,7 @@ struct OverlappingWFCOptions {
 };
 
 template<class InputIt, class T>
-constexpr InputIt find(InputIt first, InputIt last, const T& value)
+InputIt find(InputIt first, InputIt last, const T& value)
 {
     for (; first != last; ++first) {
         if (*first == value) {


### PR DESCRIPTION
Fixing for M1 by adding a flag to use C++ 11 and changing a C++ line of code that wasn't adapted to C++11 when tested on M1.