### PR TITLE
Added rigidbody export and missing parameters

### DIFF
--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/Exporter.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/Exporter.cs
@@ -55,6 +55,7 @@ namespace SimEnv.GLTF {
             GLTFImage.Export(gltfObject, imageDict);
             KHRLightsPunctual.Export(gltfObject, nodes);
             HFColliders.Export(gltfObject, nodes);
+            HFRigidbodies.Export(gltfObject, nodes);
             GLTFBuffer.Export(gltfObject, bufferData, filepath);
 
             return gltfObject;

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/GLTFNode.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/GLTFNode.cs
@@ -249,6 +249,9 @@ namespace SimEnv.GLTF {
                                 rb.mass = rigidbody.mass;
                                 rb.drag = rigidbody.drag;
                                 rb.angularDrag = rigidbody.angular_drag;
+                                rb.useGravity = rigidbody.use_gravity;
+                                rb.collisionDetectionMode = rigidbody.continuous ? CollisionDetectionMode.Continuous : CollisionDetectionMode.Discrete;
+                                rb.isKinematic = rigidbody.kinematic;
 
                                 foreach (string constraint in rigidbody.constraints) {
                                     switch (constraint) {

--- a/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/HF_colliders.cs
+++ b/integrations/Unity/simenv-unity/Assets/SimEnv/Runtime/GLTF/HF_colliders.cs
@@ -66,9 +66,8 @@ namespace SimEnv.GLTF {
             Collider[] cols = node.transform.GetComponents<Collider>();
             if (cols.Length == 0)
                 return null;
-            else if (cols.Length > 1) {
+            else if (cols.Length > 1)
                 Debug.LogWarning($"Node {node.name} has multiple colliders. Ignoring extras.");
-            }
             Collider col = cols[0];
             GLTFCollider collider = new GLTFCollider();
             if (col is BoxCollider) {

--- a/src/simenv/assets/gltf_export.py
+++ b/src/simenv/assets/gltf_export.py
@@ -549,6 +549,9 @@ def add_rigidbody_to_model(
         drag=node_rb.drag,
         angular_drag=node_rb.angular_drag,
         constraints=node_rb.constraints,
+        use_gravity=node_rb.use_gravity,
+        continuous=node_rb.continuous,
+        kinematic=node_rb.kinematic,
     )
 
     # If we have already created exactly the same rigidbody we avoid double storing

--- a/src/simenv/assets/gltflib/models/extensions/hf_rigidbodies.py
+++ b/src/simenv/assets/gltflib/models/extensions/hf_rigidbodies.py
@@ -19,6 +19,9 @@ class HFRigidbodiesRigidbody:
     angular_drag: Optional[float] = None
     constraints: Optional[List[str]] = None
     name: Optional[str] = None
+    use_gravity: Optional[bool] = None
+    continuous: Optional[bool] = None
+    kinematic: Optional[bool] = None
 
 
 @dataclass_json

--- a/src/simenv/assets/rigidbody.py
+++ b/src/simenv/assets/rigidbody.py
@@ -51,6 +51,19 @@ class RigidBody:
              FreezeRotationX, FreezeRotationY, FreezeRotationZ,
              FreezePosition, FreezeRotation, FreezeAll]
 
+    use_gravity : bool, optional
+        Whether the rigidbody should ignore gravity
+
+    continuous : bool, optional
+        Whether to use continuous collision detection, for slower
+            but more precise collision detection (recommended for
+            small but fast-moving objects)
+
+    kinematic : bool, optional
+        Whether to ignore force collisions and treat the rigidbody
+            as kinematic. Equivalent to isKinematic in Unity
+            and custom_integrator in Godot
+
     """
 
     __NEW_ID: ClassVar[int] = itertools.count()  # Singleton to count instances of the classes for automatic naming
@@ -59,6 +72,9 @@ class RigidBody:
     drag: Optional[float] = None
     angular_drag: Optional[float] = None
     constraints: Optional[List[str]] = None
+    use_gravity: Optional[bool] = None
+    continuous: Optional[bool] = None
+    kinematic: Optional[bool] = None
 
     name: Optional[str] = None
 
@@ -79,6 +95,13 @@ class RigidBody:
         for contraint in self.constraints:
             if contraint not in ALLOWED_CONSTRAINTS:
                 raise ValueError(f"Contraint {contraint} not in allowed list: {ALLOWED_CONSTRAINTS}")
+
+        if self.use_gravity is None:
+            self.use_gravity = True
+        if self.continuous is None:
+            self.continuous = False
+        if self.kinematic is None:
+            self.kinematic = False
 
         if self.name is None:
             id = next(self.__class__.__NEW_ID)


### PR DESCRIPTION
- Added exporting rigidbodies from Unity
- Adding missing parameters at the intersection of Unity/Godot rigidbodies
  - Continuous, which allows more precise but slower collision detection
  - Use_gravity, whether to ignore gravity. Godot supports a gravity scale float, but Unity only allows on/off.
  - Kinematic, for a rigidbody to trigger collision events without applying forces. This is called isKinematic in Unity and custom_integrator in Godot.