### PR TITLE
Quick hotfix for headless mode not working

### DIFF
--- a/environments/xland/scripts/sb3_training.py
+++ b/environments/xland/scripts/sb3_training.py
@@ -25,8 +25,7 @@ if __name__ == "__main__":
         pool_fn = make_pool(
             executable=args.build_exe,
             port=55000 + i,
-            headless=False,
-            # headless=True,
+            headless=True,
             sample_from=example_map,
             engine="Unity",
             seed=None,
@@ -36,6 +35,8 @@ if __name__ == "__main__":
             height=6,
             n_maps=12,
             n_show=4,
+            frame_rate=24,
+            frame_skip=4,
         )
         pool_fns.append(pool_fn)
 

--- a/environments/xland/src/xland/rl_scene.py
+++ b/environments/xland/src/xland/rl_scene.py
@@ -17,6 +17,8 @@ def create_map_pool(
     n_show=9,
     port=None,
     headless=None,
+    frame_rate=None,
+    frame_skip=None,
     **kwargs,
 ):
     """
@@ -54,6 +56,9 @@ def create_map_pool(
         map_height=height,
         engine_exe=executable,
         engine_port=port,
+        engine_headless=headless,
+        frame_rate=frame_rate,
+        frame_skip=frame_skip,
     )
 
     if max_iterations == 0:
@@ -75,6 +80,8 @@ def make_pool(
     neighbors=None,
     seed=0,
     headless=None,
+    frame_rate=None,
+    frame_skip=None,
     **kwargs,
 ):
     """
@@ -94,6 +101,8 @@ def make_pool(
             headless=headless,
             n_maps=n_maps,
             n_show=n_show,
+            frame_rate=frame_rate,
+            frame_skip=frame_skip,
             **kwargs,
         )
         return pool

--- a/src/simenv/engine/unity_engine.py
+++ b/src/simenv/engine/unity_engine.py
@@ -12,17 +12,11 @@ class UnityEngine(Engine):
         self,
         scene,
         auto_update=True,
-        start_frame=0,
-        end_frame=500,
-        frame_rate=24,
         engine_exe=None,
         engine_headless=None,
         engine_port=55000,
     ):
         super().__init__(scene=scene, auto_update=auto_update)
-        self.start_frame = start_frame
-        self.end_frame = end_frame
-        self.frame_rate = frame_rate
 
         self.host = "127.0.0.1"
         self.port = engine_port

--- a/src/simenv/rl/wrappers/pooled_env.py
+++ b/src/simenv/rl/wrappers/pooled_env.py
@@ -56,7 +56,8 @@ class Map:
 
 class MapPool:
     def __init__(
-        self, map_fn, n_maps=None, n_show=None, map_width=None, map_height=None, padding=None, **engine_kwargs
+        self, map_fn, n_maps=None, n_show=None, map_width=None, map_height=None, padding=None,
+            frame_rate=None, frame_skip=None, **engine_kwargs
     ):
         if n_maps is None:
             n_maps = 1
@@ -92,7 +93,12 @@ class MapPool:
             map = Map(self.scene, root)
             self.maps.append(map)
 
-        self.scene.show()
+        show_kwargs = {}
+        if frame_rate is not None:
+            show_kwargs["frame_rate"] = frame_rate
+        if frame_skip is not None:
+            show_kwargs["frame_skip"] = frame_skip
+        self.scene.show(**show_kwargs)
 
         self.active_maps = Queue()
         self.inactive_maps = Queue()


### PR DESCRIPTION
- Passed headless to engine
- Added example of `frame_skip` and `frame_rate` being passed through show in xland `sb3_training`