### PR TITLE
Updated Unity end-to-end to run in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ test:
 	python -m pytest -n auto --dist=loadfile -s -v  --ignore=tests/test_gltflib/ ./tests/
 
 unity-test:
-	python -m pytest -n 1 -s -v  ./integrations/Unity/tests/ --build_exe $(BUILD_EXE)
+	python -m pytest -n auto -s -v  ./integrations/Unity/tests/ --build_exe $(BUILD_EXE)

--- a/examples/cartpole.py
+++ b/examples/cartpole.py
@@ -23,19 +23,19 @@ scene += sm.Camera(
 )
 
 base = sm.Cylinder(name="base", direction=(1, 0, 0), radius=0.05, height=30, material=material.Material.GRAY50)
-base.physics_component = sm.ArticulatedBodyComponent(
+base.physics_component = sm.ArticulationBodyComponent(
     "prismatic", immovable=True, use_gravity=False
 )  # note for the base the joint type is ignored
 
 
 cart = sm.Box(name="cart", bounds=[cart_width, cart_height, cart_depth])
 
-cart.physics_component = sm.ArticulatedBodyComponent("prismatic", immovable=False, use_gravity=True)
+cart.physics_component = sm.ArticulationBodyComponent("prismatic", immovable=False, use_gravity=True)
 mapping = [
     sm.ActionMapping("add_force", axis=[1, 0, 0], amplitude=10.0),
     sm.ActionMapping("add_force", axis=[-1, 0, 0], amplitude=10.0),
 ]
-cart.controller = sm.Controller(n=2, mapping=mapping)
+cart.actuator = sm.Actuator(n=2, mapping=mapping)
 cart += sm.RewardFunction(
     type="timeout",
     distance_metric="euclidean",
@@ -53,7 +53,7 @@ pole = sm.Cylinder(
     height=pole_height,
     rotation=[0, 0, 0],
 )
-pole.physics_component = sm.ArticulatedBodyComponent(
+pole.physics_component = sm.ArticulationBodyComponent(
     "revolute", anchor_position=[0, -pole_height / 2, 0], anchor_rotation=[0, 1, 0, 1]
 )
 cart += pole

--- a/integrations/Unity/tests/conftest.py
+++ b/integrations/Unity/tests/conftest.py
@@ -1,8 +1,23 @@
+import socket
+
 import pytest
 
 
 def pytest_addoption(parser):
     parser.addoption("--build_exe", action="store", help="path to Unity build")
+
+
+@pytest.fixture(scope="session")
+def port_number(worker_id):
+    """use a different port in each xdist worker"""
+    port = 56000 + hash(worker_id) % 1024
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if s.connect_ex(("localhost", port)) == 0:
+            port = 58000 + hash(worker_id) % 1024  # test another port
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                if s.connect_ex(("localhost", port)) == 0:
+                    raise Exception("No available port found")
+    return port
 
 
 @pytest.fixture(scope="session")

--- a/integrations/Unity/tests/test_action_add_force.py
+++ b/integrations/Unity/tests/test_action_add_force.py
@@ -6,8 +6,8 @@ import pytest
 import simenv as sm
 
 
-def test_add_force(build_exe):
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -86,9 +86,8 @@ def test_add_force(build_exe):
     time.sleep(2)
 
 
-def test_add_force_is_impulse(build_exe):
-    """Comparing two objects under an action with and without impulse"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_is_impulse(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -155,9 +154,8 @@ def test_add_force_is_impulse(build_exe):
     scene.close()
 
 
-def test_add_force_local_coordinates(build_exe):
-    """Comparing two rotated objects under an action with different local coordinates"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_local_coordinates(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -215,9 +213,8 @@ def test_add_force_local_coordinates(build_exe):
     scene.close()
 
 
-def test_add_force_amplitude(build_exe):
-    """Comparing two objects under an action with different amplitude"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_amplitude(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -267,9 +264,8 @@ def test_add_force_amplitude(build_exe):
     scene.close()
 
 
-def test_add_force_offset(build_exe):
-    """Comparing two objects under an action with different offsets"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_offset(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -319,9 +315,8 @@ def test_add_force_offset(build_exe):
     scene.close()
 
 
-def test_add_force_max_velocity(build_exe):
-    """Comparing two objects under an action with different max velocities"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_max_velocity(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 

--- a/integrations/Unity/tests/test_action_add_torque.py
+++ b/integrations/Unity/tests/test_action_add_torque.py
@@ -3,8 +3,8 @@ import pytest
 import simenv as sm
 
 
-def test_add_torque(build_exe):
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -83,9 +83,8 @@ def test_add_torque(build_exe):
     scene.close()
 
 
-def test_add_torque_is_impulse(build_exe):
-    """Comparing two objects under an action with and without impulse"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque_is_impulse(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -152,9 +151,8 @@ def test_add_torque_is_impulse(build_exe):
     scene.close()
 
 
-def test_add_torque_local_coordinates(build_exe):
-    """Comparing two rotated objects under an action with different local coordinates"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque_local_coordinates(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -227,9 +225,8 @@ def test_add_torque_local_coordinates(build_exe):
     scene.close()
 
 
-def test_add_torque_amplitude(build_exe):
-    """Comparing two objects under an action with different amplitude"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque_amplitude(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -292,9 +289,8 @@ def test_add_torque_amplitude(build_exe):
     scene.close()
 
 
-def test_add_torque_offset(build_exe):
-    """Comparing two objects under an action with different offsets"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque_offset(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -357,9 +353,8 @@ def test_add_torque_offset(build_exe):
     scene.close()
 
 
-def test_add_torque_max_velocity(build_exe):
-    """Comparing two objects under an action with different max velocities"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_torque_max_velocity(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 

--- a/integrations/Unity/tests/test_action_change_position.py
+++ b/integrations/Unity/tests/test_action_change_position.py
@@ -3,8 +3,8 @@ import pytest
 import simenv as sm
 
 
-def test_change_position(build_exe):
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_change_position(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -72,9 +72,8 @@ def test_change_position(build_exe):
     scene.close()
 
 
-def test_change_position_local_coordinates(build_exe):
-    """Comparing two rotated objects under an action with different local coordinates"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_change_position_local_coordinates(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -124,9 +123,8 @@ def test_change_position_local_coordinates(build_exe):
     scene.close()
 
 
-def test_change_position_amplitude(build_exe):
-    """Comparing two objects under an action with different amplitude"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_change_position_amplitude(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -164,9 +162,8 @@ def test_change_position_amplitude(build_exe):
     scene.close()
 
 
-def test_change_position_offset(build_exe):
-    """Comparing two objects under an action with different offsets"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_change_position_offset(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 

--- a/integrations/Unity/tests/test_action_metadata.py
+++ b/integrations/Unity/tests/test_action_metadata.py
@@ -11,8 +11,8 @@ import simenv as sm
 # sm.ActionMapping("set_rotation", axis=[1, 0, 0], use_local_coordinates=False),
 
 
-def test_no_action(build_exe):
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_no_action(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -63,9 +63,11 @@ def test_no_action(build_exe):
     assert new_velocity == original_velocity
     assert new_angular_velocity == original_angular_velocity
 
+    scene.close()
 
-def test_add_force(build_exe):
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+
+def test_add_force(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -142,9 +144,8 @@ def test_add_force(build_exe):
     scene.close()
 
 
-def test_add_force_time_step(build_exe):
-    """Changing the framerate of the test_add_force test to 100 frame per second"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_time_step(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 
@@ -189,9 +190,8 @@ def test_add_force_time_step(build_exe):
     scene.close()
 
 
-def test_add_force_frame_skip(build_exe):
-    """Changing the frameskip of the test_add_force_time_step test to skip every 5 frames observations"""
-    scene = sm.Scene(engine="unity", engine_exe=build_exe) + sm.LightSun(
+def test_add_force_frame_skip(build_exe, port_number):
+    scene = sm.Scene(engine="unity", engine_exe=build_exe, engine_port=port_number) + sm.LightSun(
         name="sun", position=[0, 20, 0], intensity=0.9
     )
 

--- a/src/simenv/assets/action_mapping.py
+++ b/src/simenv/assets/action_mapping.py
@@ -50,13 +50,13 @@ class ActionMapping:
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.AddRelativeTorque.html)
             - "add_force_at_position": add a force to the object at a position in the object's local coordinate system
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.AddForceAtPosition.html)
-            - "change_position": move the object along an axis
+            - "change_position": teleport the object along an axis
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.MovePosition.html)
-            - "change_rotation": rotate the object around an axis
+            - "change_rotation": teleport the object around an axis
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.MoveRotation.html)
-            - "set_position": Set the object's position to 'position'
+            - "set_position": teleport the object's position to 'position'
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.MovePosition.html)
-            - "set_rotation": Set the object's rotation to 'rotation'
+            - "set_rotation": teleport the object's rotation to 'rotation'
                 (see https://docs.unity3d.com/ScriptReference/Rigidbody.MoveRotation.html)
         axis (List[float] Vector3): the axis of the action to be applied along or around
         amplitude (float): the amplitude of the action to be applied (see below for details)
@@ -75,6 +75,7 @@ class ActionMapping:
     "max_velocity_threshold" can be used to limit the max resulting velocity or angular velocity after the action was applied :
         - max final velocity for "add_force" actions (in m/s) – only apply the action if the current velocity is below this value
         - max angular velocity for "add_torque" actions (in rad/s) - only apply the action if the current angular velocity is below this value
+        Long discussion on Unity here: https://forum.unity.com/threads/terminal-velocity.34667/
     """
 
     action: str


### PR DESCRIPTION
You can now run the end-to-end Unity test by:
- compiling Unity for your platform
- setting `BUILD_EXE` env var to point to the Unity build
- run `make unity-test`