### PR TITLE
Trying to integrate ppo with mountain car

### DIFF
--- a/examples/rl_mountain_car.py
+++ b/examples/rl_mountain_car.py
@@ -1,0 +1,64 @@
+import argparse
+
+import simenv as sm
+from simenv.assets.action_mapping import ActionMapping
+from stable_baselines3 import PPO
+
+def create_scene(build_exe=None, gltf_path=None):
+    try:
+        raise Exception
+        scene = sm.Scene.create_from("simenv-tests/MountainCar/MountainCar.gltf")
+    except Exception as e:
+        print(e)
+        print("Failed to load from hub, loading from path: " + gltf_path)
+        scene = sm.Scene.create_from(gltf_path, engine="Unity", engine_exe=build_exe)
+
+    return scene
+
+
+def add_rl_components_to_scene(scene):
+    actor = scene.Cart
+    # actor.name = "actor"
+
+    # Add action mappings, moving left and right
+    mapping = [
+        ActionMapping("add_force", axis=[1, 0, 0], amplitude=300),
+        ActionMapping("add_force", axis=[-1, 0, 0], amplitude=300),
+    ]
+    actor.actuator = sm.Actuator(mapping=mapping, n=2)
+
+    # Add rewards, reaching the top of the right hill
+    reward_entity = sm.Asset(name="reward_entity", position=[-40, 21, 0])
+    scene += reward_entity
+    reward = sm.RewardFunction(entity_a=reward_entity, entity_b=actor)
+    actor += reward
+
+    # Add state sensor, for position of agent
+    actor += sm.StateSensor(target_entity=actor, properties=["position"])
+
+    return scene
+
+if __name__ == "__main__":
+    DYLAN_GLTF_PATH = "C:\\Users\\dylan\\Documents\\huggingface\\simenv\\integrations\\Unity\\simenv-unity\\Assets\\GLTF\\mountaincar\\Exported\\MountainCar.gltf"
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--build_exe", help="path to unity engine build executable", required=False, type=str, default=None
+    )
+    parser.add_argument("--gltf_path", help="path to the gltf file", required=False, type=str, default="simenv-tests/MountainCar/MountainCar.gltf")
+
+    parser.add_argument("-n", "--n_frames", help="number of frames to simulate", required=False, type=int, default=30)
+    args = parser.parse_args()
+
+    scene = create_scene(args.build_exe, args.gltf_path)
+    scene = add_rl_components_to_scene(scene)
+    print(scene)
+    env = sm.RLEnv(scene)
+    env.reset()
+
+    for i in range(10000):
+        obs, reward, done, info = env.step()
+        print(f"step {i}, reward {reward}, obs {obs}")
+
+
+    input("Press enter to continue...")

--- a/examples/rl_mountain_car.py
+++ b/examples/rl_mountain_car.py
@@ -1,4 +1,5 @@
 import argparse
+import pdb
 
 import simenv as sm
 from simenv.assets.action_mapping import ActionMapping
@@ -34,7 +35,7 @@ def add_rl_components_to_scene(scene):
     actor += reward
 
     # Add state sensor, for position of agent
-    actor += sm.StateSensor(target_entity=actor, properties=["position"])
+    actor += sm.StateSensor(target_entity=actor, reference_entity=reward_entity, properties=["position"])
 
     return scene
 
@@ -55,6 +56,9 @@ if __name__ == "__main__":
     print(scene)
     env = sm.RLEnv(scene)
     env.reset()
+    # import ipdb; pdb.set_trace()
+    policy = PPO('MultiInputPolicy', env, verbose=1)
+    policy.learn(total_timesteps=1000)
 
     for i in range(10000):
         obs, reward, done, info = env.step()


### PR DESCRIPTION
Has a similar bug to what I was experiencing in #147, hangs on `env.step()` and need to investigate in Unity editor to debug. We should figure out ways to make this less opaque for users.

**Update**: It was the same problem with `StateSensor` needing a `reference_entity`.

This made me realize I haven't worked with the `Dict` observation space before. I think that we should probably concatenate observations or make it possible to lock the observation space when we init the environment?

