### PR TITLE
hotfix for the Actor Camera Sensor

### DIFF
--- a/integrations/Unity/simulate-unity/Assets/SimEnv/Runtime/RLActors/Sensors/CameraSensor.cs
+++ b/integrations/Unity/simulate-unity/Assets/SimEnv/Runtime/RLActors/Sensors/CameraSensor.cs
@@ -40,7 +40,8 @@ namespace Simulate {
         }
 
         public void AddObsToBuffer(Buffer buffer, int mapIndex, int actorIndex) {
-            int startingIndex = mapIndex * actorIndex * GetSize();
+            // TODO This needs to be adjusted for a multiagent setting to include the number of actors
+            int startingIndex = mapIndex * GetSize();
             if (!cached) {
                 RenderTexture activeRenderTexture = RenderTexture.active;
                 RenderTexture.active = renderCamera.camera.targetTexture;

--- a/src/simulate/assets/actors.py
+++ b/src/simulate/assets/actors.py
@@ -145,7 +145,7 @@ class EgocentricCameraActor(Capsule):
         camera_name = None
         if name is not None:
             camera_name = f"{name}_camera"
-        self.camera = Camera(name=camera_name, width=camera_width, height=camera_height, position=[0, 0.75, 0])
+        self.camera = Camera(name=camera_name, width=camera_width, height=camera_height, position=[0, 0.25, 0])
         children = children + self.camera if children is not None else self.camera
 
         super().__init__(


### PR DESCRIPTION
hotfix as all but the first sensor was not indexing the sensor buffer correctly
also lowers the default height of the camera sensor as it was too high