### PR TITLE
fixed simple and mountaincar examples

### DIFF
--- a/examples/basic/simple_physics.py
+++ b/examples/basic/simple_physics.py
@@ -34,22 +34,23 @@ def create_scene(build_exe=None):
         bounds=[-10, 10, -0.1, 0, -10, 10],
         material=sm.Material.GRAY75,
         with_collider=True,
+        with_physics_component=False,
     )
 
     # Add a cube that will fall
-    cube = sm.Box(name="cube", position=[0, 3, 0], scaling=[1, 1, 1], material=sm.Material.GRAY50, with_collider=True)
-    scene += cube
-
-    # Add a RigidBodyComponent to the cube
-    # This will enable physics simulation, and cause the cube to fall
-    cube.physics_component = sm.RigidBodyComponent()
+    scene += sm.Box(
+        name="cube",
+        position=[0, 3, 0],
+        scaling=[1, 1, 1],
+        material=sm.Material.GRAY50,
+        with_collider=True,
+        with_physics_component=True
+    )
 
     # Add a camera to record the scene
     scene += sm.Camera(name="camera", position=[0, 2, -10])
 
     # Calling show() is required for the scene to be initialized
-    # show() allows several engine keyword arguments, which are passed to the Unity backend
-    # You can find all available keyword arguments TODO: here
     scene.show()
 
     return scene
@@ -84,7 +85,7 @@ def simulate(scene, n_frames=30):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--build_exe", help="path to unity engine build executable", required=False, type=str, default=None
+        "--build_exe", help="path to unity engine build executable", required=False, type=str, default=""
     )
     parser.add_argument("-n", "--n_frames", help="number of frames to simulate", required=False, type=int, default=30)
     args = parser.parse_args()

--- a/examples/basic/simple_physics.py
+++ b/examples/basic/simple_physics.py
@@ -44,7 +44,7 @@ def create_scene(build_exe=None):
         scaling=[1, 1, 1],
         material=sm.Material.GRAY50,
         with_collider=True,
-        with_physics_component=True
+        with_physics_component=True,
     )
 
     # Add a camera to record the scene

--- a/examples/mountaincar.py
+++ b/examples/mountaincar.py
@@ -4,18 +4,6 @@ import simulate as sm
 from simulate.assets.action_mapping import ActionMapping
 
 
-def create_scene(build_exe=None, gltf_path=None):
-    try:
-        raise Exception
-        scene = sm.Scene.create_from("simulate-tests/MountainCar/MountainCar.gltf")
-    except Exception as e:
-        print(e)
-        print("Failed to load from hub, loading from path: " + gltf_path)
-        scene = sm.Scene.create_from(gltf_path, engine="Unity", engine_exe=build_exe)
-
-    return scene
-
-
 def add_rl_components_to_scene(scene):
     actor = scene.MountainCar_Cart
     actor.is_actor = True
@@ -38,18 +26,13 @@ def add_rl_components_to_scene(scene):
 
 
 if __name__ == "__main__":
-    DYLAN_GLTF_PATH = "C:\\Users\\dylan\\Documents\\huggingface\\simulate\\integrations\\Unity\\simulate-unity\\Assets\\GLTF\\mountaincar\\Exported\\MountainCar.gltf"
-
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--build_exe", help="path to unity engine build executable", required=False, type=str, default=None
-    )
-    parser.add_argument("--gltf_path", help="path to the gltf file", required=False, type=str, default=DYLAN_GLTF_PATH)
-
+    parser.add_argument("--build_exe", help="path to unity engine build executable", required=False, type=str, default="")
     parser.add_argument("-n", "--n_frames", help="number of frames to simulate", required=False, type=int, default=30)
     args = parser.parse_args()
 
-    scene = create_scene(args.build_exe, args.gltf_path)
+    build_exe = args.build_exe if args.build_exe != "None" else None
+    scene = sm.Scene.create_from("simulate-tests/MountainCar/MountainCar.gltf", engine="Unity", engine_exe=build_exe)
     add_rl_components_to_scene(scene)
 
     env = sm.RLEnv(scene)

--- a/examples/mountaincar.py
+++ b/examples/mountaincar.py
@@ -27,7 +27,9 @@ def add_rl_components_to_scene(scene):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--build_exe", help="path to unity engine build executable", required=False, type=str, default="")
+    parser.add_argument(
+        "--build_exe", help="path to unity engine build executable", required=False, type=str, default=""
+    )
     parser.add_argument("-n", "--n_frames", help="number of frames to simulate", required=False, type=int, default=30)
     args = parser.parse_args()
 

--- a/src/simulate/assets/gltf_import.py
+++ b/src/simulate/assets/gltf_import.py
@@ -26,7 +26,7 @@ from huggingface_hub import hf_hub_download
 
 from . import Asset, Camera, Light, Material, Object3D
 from .gltf_extension import GLTF_EXTENSIONS_REGISTER, GLTF_NODES_EXTENSION_CLASS, process_tree_after_gltf
-from .gltflib import GLTF, FileResource, TextureInfo, Base64Resource
+from .gltflib import GLTF, Base64Resource, FileResource, TextureInfo
 from .gltflib.enums import AccessorType, ComponentType
 
 

--- a/src/simulate/assets/object.py
+++ b/src/simulate/assets/object.py
@@ -58,7 +58,7 @@ class Object3D(Asset):
     ):
         super().__init__(name=name, position=position, is_actor=is_actor, parent=parent, children=children, **kwargs)
 
-        if with_physics_component:
+        if self.physics_component is None and with_physics_component:
             self.physics_component = RigidBodyComponent()
 
         self.mesh = mesh if mesh is not None else pv.PolyData()


### PR DESCRIPTION
- Updated `simple_simulation` to work correctly with physics components update
- Uploaded embedded mountaincar gltf at https://huggingface.co/spaces/simulate-tests/MountainCar/blob/main/MountainCar.gltf
- Updated mountaincar example to only load from hub
- `gltf_import` fixes:
    - Added `with_physics_component=False` common_kwarg so that it doesn't override rigidbodies
    - Added check for embedded image resource to load from b64bytes