### PR TITLE
Fix PR doc build

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,5 +15,3 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: simulate
       install_libgl1: true
-    secrets:
-      token: ${{ secrets.HUGGINGFACE_PUSH }}


### PR DESCRIPTION
As can be seen [here](https://github.com/huggingface/simulate/actions/runs/3135806521/jobs/5098930783), PR doc build was failing with:

> Exception: create_deletions failed (GET tree root): {"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}


Not sure if the credentials issue comes from name change. However, since the repo is now public, there is no need to provide `secrets/token`. Therefore, removing that part entirely as [here](https://github.com/huggingface/simulate/pull/262/files)