### PR TITLE
[docs] Fix parsing error on `tutorials/run_on_gcp` doc page

### DIFF
--- a/docs/source/tutorials/run_on_gcp.mdx
+++ b/docs/source/tutorials/run_on_gcp.mdx
@@ -56,7 +56,7 @@ DISPLAY=:0 glxgears
 nvidia-smi # xorg should show up in the running programs
 ```
 
-**Important!** The DISPLAY=:0 envirionment variable must be set befire you launch Simulate.
+**Important!** The `DISPLAY=:0` envirionment variable must be set before you launch Simulate.
 
 ```
 export DISPLAY=:0


### PR DESCRIPTION
`DISPLAY=:0` needed to be wrapped up inside `. Otherwise, it was causing parsing error [here](https://github.com/huggingface/moon-landing/blob/ec102874d1d323cbe0a42c98a5125400d4a9353b/server/app/contentRoutes.ts#L307)

<img width="603" alt="image" src="https://user-images.githubusercontent.com/11827707/193776602-ee5a15f9-6b18-4c54-bc00-d8b912094de7.png">
