### PR TITLE
Debugging weird doc behavior

### DIFF
--- a/docs/source/api/sensors.mdx
+++ b/docs/source/api/sensors.mdx
@@ -12,8 +12,8 @@ specific language governing permissions and limitations under the License.
 
 # Sensors
 
-[//]: # ([[autodoc]] StateSensor)
+[[autodoc]] StateSensor
 
-[//]: # ([[autodoc]] RaycastSensor)
+[[autodoc]] RaycastSensor
 
 Under construction 🚧.


### PR DESCRIPTION
cc @mishig25 -- it should show up shortly in the build documentation action.

Will add a screenshot.

```
TypeError: Error while preprocessing /private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/src/routes/api/sensors.mdx - Cannot convert undefined or null to object
    at hasOwnProperty (<anonymous>)
    at hasChildren (/private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/node_modules/domhandler/lib/node.js:369:44)
    at Object.innerText (/private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/node_modules/domutils/lib/stringify.js:79:38)
    at file:///private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/preprocess.js:79:29
    at async Promise.all (index 0)
    at async replaceAsync (file:///private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/preprocess.js:332:26)
    at async markup (file:///private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/preprocess.js:29:13)
    at async process_markup (file:///private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/node_modules/svelte/compiler.mjs:32121:23)
    at async preprocess (file:///private/var/folders/5_/bct76xnj7815tfx8xm7q
xv6w0000gn/T/tmpn69q2l9p/kit/node_modules/svelte/compiler.mjs:32151:30)
    at async compileSvelte2 (file:///private/var/folders/5_/bct76xnj7815tfx8xm7qxv6w0000gn/T/tmpn69q2l9p/kit/node_modules/@sveltejs/vite-plugin-svelte/dist/index.js:299:22)
```

<img width="1624" alt="Screen Shot 2022-10-04 at 9 52 35 AM" src="https://user-images.githubusercontent.com/10695622/193837833-08db3024-2649-4377-9c24-c01c817c2844.png">
