### PR TITLE
Initial Take Cover Environment attempt + discussion

### DIFF
--- a/examples/rl/sb3_take_cover.py
+++ b/examples/rl/sb3_take_cover.py
@@ -1,0 +1,269 @@
+# Copyright 2022 The HuggingFace Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+
+from turtle import left, right
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
+import argparse
+import random
+import numpy as np
+import matplotlib.pyplot as plt
+import itertools
+
+from simulate import logging
+
+
+logger = logging.get_logger(__name__)
+
+try:
+    from stable_baselines3 import PPO
+except ImportError:
+    logger.warning(
+        "stable-baseline3 is required for this example and is not installed. To install: pip install simulate[sb3]"
+    )
+    exit()
+
+import simulate as sm
+
+
+CAMERA_HEIGHT = 40
+CAMERA_WIDTH = 64
+
+
+def rgb2gray(rgb):
+    return np.dot(rgb[...,:3], [0.2989, 0.5870, 0.1140])
+
+class TakeCoverEnv(sm.RLEnv):
+    def __init__(
+        self,
+        scene_or_map_fn: Union[Callable, sm.Scene],
+        n_maps: Optional[int] = 1,
+        n_show: Optional[int] = 1,
+        time_step: Optional[float] = 1 / 30.0,
+        frame_skip: Optional[int] = 4,
+        **engine_kwargs,
+    ):
+        super().__init__(
+            scene_or_map_fn=scene_or_map_fn,
+            n_maps=n_maps,
+            n_show=n_show,
+            time_step=time_step,
+            frame_skip=frame_skip,
+            **engine_kwargs
+        )
+        self.action_tags = ["actor_action", "projectile_action_0", "projectile_action_1", "projectile_action_2"]
+
+        self.projectile_nodes = ["projectile_0_0", "projectile_1_0", "projectile_2_0"]
+        self.projectile_actions = ["projectile_action_0", "projectile_action_1", "projectile_action_2"]
+
+        # self.projectile_action_acceleration_indices = 1
+
+        self.projectile_position_control_indices = np.arange(2,9)
+
+    def check_projectile_wall_collision(self, event):
+        needs_reset = False
+        nodes = event['nodes']
+        action_dict = {}
+        random_positions = list(np.random.choice(self.projectile_position_control_indices, 3, replace=False))
+        for i, projectile in enumerate(self.projectile_nodes):
+            if nodes[projectile]['position'][-1] <= -4.8:
+                needs_reset = True
+                action_dict[self.projectile_actions[i]] = [
+                    [
+                        [int(random_positions[i])]
+                    ]
+                ]
+
+        return needs_reset, action_dict
+
+    def set_random_positions(self):
+        action_dict = {}
+        random_positions = list(np.random.choice(self.projectile_position_control_indices, 3, replace=False))
+        for i, projectile in enumerate(self.projectile_nodes):
+            action_dict[self.projectile_actions[i]] = [
+                [
+                    [int(random_positions[i])]
+                ]
+            ]
+        self.step_send_async(
+            action_dict
+        )
+        self.scene.engine.step_recv_async()
+
+
+    def reset(self) -> Dict:
+        """
+        Resets the actors and the scene of the environment.
+
+        Returns:
+            obs (`Dict`): the observation of the environment after reset.
+        """
+        self.scene.reset()
+
+        # To extract observations, we do a "fake" step (no actual simulation with frame_skip=0)
+        event = self.scene.step(return_frames=True, frame_skip=0)
+        obs = self._extract_sensor_obs(event["actor_sensor_buffers"])
+        obs = self._squeeze_actor_dimension(obs)
+        obs["actor_0_camera"] = obs["actor_0_camera"][0:1]
+        return obs
+
+
+    def step(self, action: Union[Dict, List, np.ndarray]) -> Tuple[Dict, np.ndarray, np.ndarray, List[Dict]]:
+        action_dict = {
+                "actor_action":[
+                    [
+                        [int(action[0])],
+                    ],
+                ],
+            }
+
+        for projectile in self.projectile_actions:
+            action_dict[projectile] = [
+                [
+                    [1],
+                ],
+            ]
+
+        self.step_send_async(action=action_dict)
+        event = self.scene.engine.step_recv_async()
+
+        obs = self._extract_sensor_obs(event["actor_sensor_buffers"])
+        reward = self._convert_to_numpy(event["actor_reward_buffer"]).flatten()[0:1]
+        done = self._convert_to_numpy(event["actor_done_buffer"]).flatten()[0:1]
+        obs = self._squeeze_actor_dimension(obs)
+        obs["actor_0_camera"] = obs["actor_0_camera"][0:1]
+        # obs = self._squeeze_actor_dimension(obs)['actor_0_camera']
+        # print("REWARD", reward)
+        # print("DONE", done)
+        # obs = np.flip(np.array(obs, dtype=np.uint8).transpose(1, 2, 0), axis=0).astype(np.uint8)
+        # obs = rgb2gray(obs)
+
+        needs_reset, projectile_reset_action_dict = self.check_projectile_wall_collision(event)
+
+        if needs_reset:
+            self.step_send_async(
+                projectile_reset_action_dict
+            )
+            self.scene.engine.step_recv_async()
+
+        return obs, reward, done, [{}]
+
+
+def create_target_projectiles(index: int, num_projectiles: int = 3):
+    projectiles = []
+    for i in range(num_projectiles):
+        target_position = [0.5*i + 0.1, 0.2, 4.0]
+        projectile = sm.Box(
+            name=f"projectile_{i}_{index}",
+            position=target_position,
+            bounds = (-0.1, 0.1, 0.1, 0.3, -0.1, 0.1),
+            material=sm.Material.RED,
+            is_actor=True,
+            physics_component=sm.RigidBodyComponent(mass=0),
+            with_collider=True,
+        )
+        projectile.physics_component.constraints = ["freeze_rotation_x", "freeze_rotation_z", "freeze_rotation_y"]
+        mapping = [
+            sm.ActionMapping("do_nothing"),
+
+            # acceleration
+            sm.ActionMapping("change_position", axis=[0, 0, -1], amplitude=0.15),
+            # sm.ActionMapping("change_position", axis=[0, 0, -1], amplitude=0.3),
+            # sm.ActionMapping("change_position", axis=[0, 0, -1], amplitude=0.1),
+
+            # set positions
+            sm.ActionMapping("set_position", position=[-3.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[-2.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[-1.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[0.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[1.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[2.0, 0.2, 4.0], use_local_coordinates=False),
+            sm.ActionMapping("set_position", position=[2.5, 0.2, 4.0], use_local_coordinates=False),
+        ]
+        projectile.actuator = sm.Actuator(n=9, actuator_tag=f"projectile_action_{i}", mapping=mapping)
+        projectiles.append(projectile)
+    return projectiles
+
+
+def generate_map(index):
+    root = sm.Asset(name=f"root_{index}")
+
+    floor = sm.Box(name=f"floor_{index}", position=[0, 0, 0], bounds=[-5, 5, 0, 0.1, -5, 5], material=sm.Material.BLUE)
+    right_wall = sm.Box(name=f"wall1_{index}", position=[-3.1, 0, 0], bounds=[0, 0.1, 0, 1, -5, 5], material=sm.Material.WHITE)
+    left_wall = sm.Box(name=f"wall2_{index}", position=[3.1, 0, 0], bounds=[0, 0.1, 0, 1, -5, 5], material=sm.Material.WHITE)
+    close_wall = sm.Box(name=f"wall4_{index}", position=[0, 0, -5], bounds=[-5, 5, 0, 1, 0, 0.1], material=sm.Material.WHITE)
+
+    root += floor
+    root += right_wall
+    root += left_wall
+    root += close_wall
+
+
+    actor = sm.EgocentricCameraActor(
+        name=f"actor_{index}",
+        position=[0.0, 0.1, -4.0],
+        material=sm.Material.GREEN,
+    )
+
+    actor.physics_component.mass = 0.0
+    actor.physics_component.constraints = ["freeze_rotation_x", "freeze_rotation_z", "freeze_position_y", "freeze_position_z"]
+
+    mapping = [
+        sm.ActionMapping("change_position", axis=[-1, 0, 0], amplitude=0.1),
+        sm.ActionMapping("change_position", axis=[1, 0, 0], amplitude=0.1),
+    ]
+    actor.actuator = sm.Actuator(n=2, actuator_tag="actor_action", mapping=mapping)
+
+    # create targets
+    projectiles = create_target_projectiles(index, 3)
+
+    # add target terminals, if the agent gets hit by any of the projectiles, the episode should end
+    for projectile in projectiles:
+        actor += sm.RewardFunction(type="sparse", entity_a=projectile, entity_b=actor, scalar=-100.0, threshold=0.5, is_terminal=True)
+
+    actor += sm.RewardFunction("timeout", scalar=1.0, threshold=200, is_terminal=True)
+    root += actor
+
+    for projectile in projectiles:
+        root += projectile
+
+    return root
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build_exe", default="", type=str, required=False, help="Pre-built unity app for simulate")
+    parser.add_argument("--n_maps", default=1, type=int, required=False, help="Number of maps to spawn")
+    parser.add_argument("--n_show", default=1, type=int, required=False, help="Number of maps to show")
+    args = parser.parse_args()
+
+    env = TakeCoverEnv(generate_map, args.n_maps, args.n_show, engine_exe=args.build_exe)
+
+    model = PPO("MultiInputPolicy", env, verbose=1, n_epochs=1)
+    model.learn(total_timesteps=10000)
+
+    print("LEARNT")
+    obs = env.reset()
+    plt.ion()
+    _, ax1 = plt.subplots(1, 1)
+    for i in range(4000):
+        action, _states = model.predict(obs)
+        obs, rewards, dones, info = env.step(action)
+        frame = np.flip(np.array(obs['actor_0_camera'][0], dtype=np.uint8).transpose(1, 2, 0), axis=0).astype(np.uint8)
+        ax1.clear()
+        ax1.imshow(frame)
+        plt.pause(0.1)
+
+    env.close()


### PR DESCRIPTION
# Take cover environment example

## Note: This probably shouldn't be merged because its a bit hacky, but just wanted to publish this as a way to discuss some stuff

First off, thanks so much for creating this library! Personally, I've been wanting something like this for so long! The ability to create Unity RL environments from plain python objects is super convenient and will definitely be super useful in creating more open-ended environments. I wanted to take a dive into the library, so I decided to try to port one of my favorite environments: Vizdoom's take-cover environment. Decided to jot down some of my notes and experience as a first time user. Also, I understand that this library is still under development and definitely has many important core design principles that I am not aware of, so take my feedback with a grain of salt :sweat_smile: 

### Environment Details
- The `take-cover` environment is a simplified version of https://github.com/shakenes/vizdoomgym/blob/master/vizdoomgym/envs/scenarios/README.md#take-cover. A video of the environment: https://www.youtube.com/watch?v=9SATUL6irFw. Basically, the agent can move left and right and has to dodge homing fireballs hurled at it. 
- The one I implemented here is super simple, as the projectiles just go in a straight line starting from random locations.

## Discussion
Hopefully this perspective is useful as I only got my hands on this recently (this week), and I've had experience with some (relatively) similar frameworks like unity-ml-agents

### Positives

- `RewardFunction` objects are super convenient and I think well designed. While simple, combining them is pretty trivial and I found them super easy to learn
- The Camera object for actors is amazingly convenient. Being able to easily attach a first-person view to an agent is incredibly useful for building RL agents that can transfer from simulation -> real world.
- Its really easy to design a simple environment (with one agent and stationary objectives / collectibles) with the built in structures. Adding walls, floors, objectives + a single agent was super easy to pick up.
- The seemless interaction with SB3 is really nice, as its trivial to train something like a PPO agent on a simple 3D environment I created.

### Some Feedback 

#### Its hard to make "dynamic" environments
The `take-cover` environment requires some more complicated, dynamic interactions:
- Projectiles that home in on the agents location
- Monsters / projectiles that spawn in random starting locations

I found this kinda hard to implement for a couple reasons:

1) Projectiles can't actually be created on the spot because after the scene is initialized, I couldn't find a way to dynamically create another object. I'm sure this is planned in the future as https://github.com/huggingface/simulate/blob/main/src/simulate/engine/unity_engine.py#L177 hasn't been implemented just yet

2) `Actor` objects seemed to be the only objects that can be really modified (for instance, moved in a particular direction: https://github.com/huggingface/simulate/blob/main/src/simulate/assets/action_mapping.py#L25). This kind of makes it tricky to add dynamic components, like projectiles, because we don't really want the policy to really take in stuff like observations from them. I do still like the idea of having "agents" be the things that can be "acted" upon, but I think that maybe having another level of abstraction, maybe something like "Actor" -> "PolicyActor" to specify which objects should be controlled by an actual policy. This might be a bit confusing and may not be the best solution, but I'll probably make a separate pr to show what I have in mind, if that seems useful.

3) Some `ActionMapping` objects are limited for some cases
The `ActionMapping` objects are really convenient for most cases, but are kind of limited in other scenarios, like when we want **conditional** actions. Like for instance, in the take cover environment we need to reset projectiles when they reach a certain threshold. This is kind of hard because `set_position` needs a hardcoded position to reset to, instead of being able to provide it dynamically, leading to some messy interactions (here I had to hardcode possible positions for the projectiles to reset to: https://github.com/shyamsn97/simulate/blob/take-cover/examples/rl/sb3_take_cover.py#L152-L158). Not sure if I missed something, but is there a way to dynamically input a new position, like an action? From my understanding this is nontrivial because the actions from the actuators, along with the scenes are converted to `gltf` and passed to unity, which I guess is why its hard to also dynamically add stuff to the scene. 

4) Hard to customize / understand `ActionMapping` objects
I found it hard to actually understand / customize action mappings. Since they're all in one class, I found it a bit confusing to figure out what each parameter did for each action type. As a possible improvement to this, I think having separate `ActionMapping` dataclasses for **each** action could make it a lot easier to understand and customize each one. For instance, a `set_position` action could be something like:

```python
@dataclass
class SetPositionActionMapping(ActionMapping):
    position: Optional[List[float]]
```
I'll probably put out a pr to also show what I have in mind for this!

5) Customizing RLEnv is a bit hacky
Not sure if the intention is to actually allow customization, but for my implementation I needed to have customized  `reset` and `step` functions, but it was a bit hacky in that I had to just copy the methods from the base. Maybe it could help to an empty function for reset + step that are just like `custom_reset` or `custom_step` that can run before / after the original methods?

#### Some bugs / weird unity stuff
I noticed with the `set_position` action, the object moves to a different position than if specified in the actual asset creation. For example:

```python
sm.Box(
            name=f"projectile_{i}_{index}",
            position=target_position,
           ...
```

would move to a different position even if  `sm.ActionMapping("set_position", target_position,  use_local_coordinates=False)` is used.

---

Sorry if this is a bit lengthy, but super excited about the future of simulate! Let me know if any of the stuff above doesn't make sense (I'm sure a lot is just my misunderstanding :smile:). Also would love to collaborate if there's some open problems that I can work on! Thanks!