### PR TITLE
Unify the step() API

### DIFF
--- a/examples/advanced/lunar_lander.py
+++ b/examples/advanced/lunar_lander.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     sc = make_lander(engine="unity", engine_exe=args.build_exe)
     sc += sm.LightSun()
 
-    env = sm.ParallelRLEnv(sc, frame_skip=1)
+    env = sm.RLEnv(sc, frame_skip=1)
     env.reset()
 
     for i in range(500):

--- a/src/simulate/engine/blender_engine.py
+++ b/src/simulate/engine/blender_engine.py
@@ -1,8 +1,22 @@
+# Copyright 2022 The HuggingFace Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import atexit
 import base64
 import json
 import socket
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..utils import logging
 from .engine import Engine
@@ -94,7 +108,7 @@ class BlenderEngine(Engine):
         command = {"type": "reset", "contents": {"message": "message"}}
         self.run_command(command)
 
-    def step(self, action: Optional[Dict] = None, **kwargs: Any):
+    def step(self, action: Optional[Dict] = None, **kwargs: Any) -> Union[Dict, str]:
         raise NotImplementedError()
 
     def render(self, path: str):

--- a/src/simulate/engine/godot_engine.py
+++ b/src/simulate/engine/godot_engine.py
@@ -16,7 +16,7 @@ import atexit
 import base64
 import json
 import socket
-from typing import TYPE_CHECKING, Any, Dict, Union, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ..utils import logging
 from .engine import Engine

--- a/src/simulate/engine/godot_engine.py
+++ b/src/simulate/engine/godot_engine.py
@@ -1,8 +1,22 @@
+# Copyright 2022 The HuggingFace Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import atexit
 import base64
 import json
 import socket
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Union, Optional
 
 from ..utils import logging
 from .engine import Engine
@@ -110,8 +124,11 @@ class GodotEngine(Engine):
     def update_all_assets(self):
         raise NotImplementedError()
 
-    def step(self, **kwargs: Any) -> Union[Dict, str]:
+    def step(self, action: Optional[Dict] = None, **kwargs: Any) -> Union[Dict, str]:
         """Step the simulation"""
+        if action is not None:
+            kwargs.update({"action": action})
+
         return self.run_command("step", **kwargs)
 
     def reset(self) -> Union[Dict, str]:

--- a/src/simulate/engine/pyvista_engine.py
+++ b/src/simulate/engine/pyvista_engine.py
@@ -14,7 +14,7 @@
 
 # Lint as: python3
 """ A PyVista plotting rendered as engine."""
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import numpy as np
 import pyvista
@@ -327,5 +327,5 @@ class PyVistaEngine(Engine):
     def reset(self):
         raise NotImplementedError()
 
-    def step(self, action=None, **kwargs):
+    def step(self, action: Optional[Dict] = None, **kwargs: Any) -> Union[Dict, str]:
         raise NotImplementedError()

--- a/src/simulate/rl/multi_proc_rl_env.py
+++ b/src/simulate/rl/multi_proc_rl_env.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import gym
 import numpy as np

--- a/src/simulate/rl/multi_proc_rl_env.py
+++ b/src/simulate/rl/multi_proc_rl_env.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import Any, Callable, List, Optional, Sequence, Type
+from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Tuple, Union
 
 import gym
 import numpy as np
@@ -61,7 +61,7 @@ class MultiProcessRLEnv(VecEnv):
         num_envs = self.n_show * self.n_parallel
         super().__init__(num_envs, observation_space, action_space)
 
-    def step(self, actions: Optional[np.array] = None):
+    def step(self, actions: Optional[Union[list, np.array]] = None) -> Tuple[Dict, np.ndarray, np.ndarray, List[Dict]]:
         """
         The step function for the environment, follows the API from OpenAI Gym.
 
@@ -74,6 +74,9 @@ class MultiProcessRLEnv(VecEnv):
             all_done (`bool`): TODO
             all_info: TODO
         """
+        if isinstance(actions, list):
+            actions = np.array(actions)
+
         for i in range(self.n_parallel):
             # TODO comment what is going on here
             action = actions[i * self.n_show : (i + 1) * self.n_show] if actions is not None else None

--- a/src/simulate/scene.py
+++ b/src/simulate/scene.py
@@ -209,25 +209,27 @@ class Scene(Asset):
         return_nodes: Optional[bool] = None,
         return_frames: Optional[bool] = None,
         **engine_kwargs: Any,
-    ) -> Any:
+    ) -> Union[Dict, str]:
         """Step the Scene.
 
-        Parameters
-        ----------
-        action: Dict[str, List[Any]]
-            The action to apply to the actors in the scene.
-            Keys are actuator_id and values are actions to apply as tensors of shapes
-            (n_maps, n_actors, action_space...)
-        time_step: Optional[float]
-            The time step to apply to the scene. If None, the time_step of the config is used.
-        frame_skip: Optional[int]
-            The number of frames to skip. If None, the frame_skip of the config is used.
-        return_nodes: Optional[bool]
-            If True, the nodes of the scene are returned. If None, the return_nodes of the config is used.
-        return_frames: Optional[bool]
-            If True, the frames of the scene are returned. If None, the return_frames of the config is used.
-        engine_kwargs: Dict
-            Additional kwargs to pass to the engine.
+        Args:
+            action: Dict[str, List[Any]]
+                The action to apply to the actors in the scene.
+                Keys are actuator_id and values are actions to apply as tensors of shapes
+                (n_maps, n_actors, action_space...)
+            time_step: Optional[float]
+                The time step to apply to the scene. If None, the time_step of the config is used.
+            frame_skip: Optional[int]
+                The number of frames to skip. If None, the frame_skip of the config is used.
+            return_nodes: Optional[bool]
+                If True, the nodes of the scene are returned. If None, the return_nodes of the config is used.
+            return_frames: Optional[bool]
+                If True, the frames of the scene are returned. If None, the return_frames of the config is used.
+            engine_kwargs: Dict
+                Additional kwargs to pass to the engine.
+
+        Returns:
+            event_data: Dict of simulation data from the scene.
         """
         if not self._is_shown:
             raise ValueError("The scene should be shown before stepping it (call scene.show()).")


### PR DESCRIPTION
Two primary points of consideration:
1. the `engine.step()` functions
2. the `env.step()` functions (RL)

Working to address #237 