### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -23,13 +23,16 @@ Install Simulate (preferentially in a virtual environment) with a simple `pip in
 Simulate comes with additional support for the gym API, stable baselines 3 and sample-factory (experimental)
 
 ### Gym Installation
+
 `pip install simulate[gym]`
 
 
 ### Gym Installation
+
 `pip install simulate[sb3]`
 
 ### Gym Installation
+
 `pip install simulate[sample-factory]`
 
 


### PR DESCRIPTION
We need spaces for the svelte markdown parser to correctly render them

Error screenshot:
<img width="352" alt="image" src="https://user-images.githubusercontent.com/11827707/194828541-e2604a6f-7aaf-4b18-aa54-4db7e1a2dc67.png">
