### PR TITLE
Fixed typo in docs link

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -33,7 +33,7 @@ specific language governing permissions and limitations under the License.
       ><div class="w-full text-center bg-gradient-to-br from-pink-400 to-pink-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Conceptual guides</div>
       <p class="text-gray-700">More discussion and explanation of the underlying concepts and ideas behind 🤗 Simulate.</p>
    </a>
-    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./api/scene"
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./api/scenes"
       ><div class="w-full text-center bg-gradient-to-br from-purple-400 to-purple-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">API</div>
       <p class="text-gray-700">Technical descriptions of how 🤗 Simulate classes and methods work.</p>
     </a>


### PR DESCRIPTION
Fixed typo in link to API docs